### PR TITLE
allow symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
   "require": {
     "php": "^7.3||^8.0",
     "ext-json": "*",
-    "symfony/config": "^5.1",
-    "symfony/console": "^5.1",
-    "symfony/framework-bundle": "^5.1",
-    "symfony/dependency-injection": "^5.1",
-    "symfony/http-kernel": "^5.1",
-    "symfony/serializer": "^5.1",
-    "symfony/yaml": "^5.1"
+    "symfony/config": "^5.1 || ^6.0",
+    "symfony/console": "^5.1 || ^6.0",
+    "symfony/framework-bundle": "^5.1 || ^6.0",
+    "symfony/dependency-injection": "^5.1 || ^6.0",
+    "symfony/http-kernel": "^5.1 || ^6.0",
+    "symfony/serializer": "^5.1 || ^6.0",
+    "symfony/yaml": "^5.1 || ^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.2",

--- a/src/Command/ConfigDumpSchemaCommand.php
+++ b/src/Command/ConfigDumpSchemaCommand.php
@@ -111,7 +111,7 @@ final class ConfigDumpSchemaCommand extends AbstractConfigCommand
         /** @var \Symfony\Component\HttpKernel\Bundle\Bundle[] $bundles */
         $bundles = $kernel->getBundles();
 
-        $container = $this->getContainerBuilder();
+        $container = $this->getContainerBuilder($kernel);
         foreach ($bundles as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);


### PR DESCRIPTION
### Description 

Allow Symfony 6.

Since Symfony 5.1 has been EOL for a while, I'd recommend bumping to 5.4, but didn't do that in this PR.

## Checklist

- [ ] Code follows the code style of this project (use `$ composer fix-cs`). 
- [ ] Change requires a change to the documentation.
- [ X] Code is ready for a review.
