### PR TITLE
fix: Symfony NumericNode min,max values are inclusive

### DIFF
--- a/src/Configuration/Serializer/Normalizer/Node/NumericNodeNormalizer.php
+++ b/src/Configuration/Serializer/Normalizer/Node/NumericNodeNormalizer.php
@@ -55,11 +55,11 @@ class NumericNodeNormalizer extends BaseNodeNormalizer
         ];
 
         if ($minValue !== null) {
-            $schema['exclusiveMinimum'] = $minValue;
+            $schema['minimum'] = $minValue;
         }
 
         if ($maxValue !== null) {
-            $schema['exclusiveMaximum'] = $maxValue;
+            $schema['maximum'] = $maxValue;
         }
 
         return $schema;


### PR DESCRIPTION
### Description 

Symfony's NumericNode min and max values are inclusive rather than exclusive (https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Config/Definition/NumericNode.php#L38. 
## Checklist

- [x] Code follows the code style of this project (use `$ composer fix-cs`).
- [x] Change requires a change to the documentation.
- [x] Code is ready for a review.
