### PR TITLE
Extension matchers

### DIFF
--- a/src/ExtensionMatcher/CompositeExtensionMatcher.php
+++ b/src/ExtensionMatcher/CompositeExtensionMatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher;
+
+/**
+ * Matches if any of the composed matchers matches.
+ *
+ * If no matchers are provided, it matches everything.
+ */
+final readonly class CompositeExtensionMatcher implements ExtensionMatcherInterface
+{
+    public function __construct(
+        private array $matchers
+    ) {
+    }
+
+    public function matches(string $alias): bool
+    {
+        if ($this->matchers === []) {
+            return true;
+        }
+
+        foreach ($this->matchers as $matcher) {
+            if ($matcher->matches($alias)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ExtensionMatcher/ExplicitExtensionMatcher.php
+++ b/src/ExtensionMatcher/ExplicitExtensionMatcher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher;
+
+/**
+ * Matches a specific, explicit extension alias.
+ */
+final readonly class ExplicitExtensionMatcher implements ExtensionMatcherInterface
+{
+    public function __construct(
+        private string $alias
+    ) {
+    }
+
+    public function matches(string $alias): bool
+    {
+        return $this->alias === $alias;
+    }
+}

--- a/src/ExtensionMatcher/ExtensionMatcherFactory.php
+++ b/src/ExtensionMatcher/ExtensionMatcherFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher;
+
+final class ExtensionMatcherFactory
+{
+    /**
+     * Create an extension matcher based on the given extension name.
+     *
+     * If the extension name contains a wildcard character (*), a WildcardExtensionMatcher is created.
+     * Otherwise, an ExplicitExtensionMatcher is created.
+     */
+    public function createMatcher(string $extension): ExtensionMatcherInterface
+    {
+        if ($this->isWildcard($extension)) {
+            return new WildcardExtensionMatcher($extension);
+        }
+
+        return new ExplicitExtensionMatcher($extension);
+    }
+
+    public function createCompositeMatcher(array $extensions): ExtensionMatcherInterface
+    {
+        $matchers = array_map(
+            fn (string $extension) => $this->createMatcher($extension),
+            $extensions
+        );
+
+        return new CompositeExtensionMatcher($matchers);
+    }
+
+    /**
+     * Check if the given extension name contains a wildcard character.
+     */
+    private function isWildcard(string $extension): bool
+    {
+        return str_contains($extension, '*');
+    }
+}

--- a/src/ExtensionMatcher/ExtensionMatcherInterface.php
+++ b/src/ExtensionMatcher/ExtensionMatcherInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher;
+
+interface ExtensionMatcherInterface
+{
+    public function matches(string $alias): bool;
+}

--- a/src/ExtensionMatcher/WildcardExtensionMatcher.php
+++ b/src/ExtensionMatcher/WildcardExtensionMatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher;
+
+/**
+ * Matches extension aliases using wildcard patterns (e.g. "acme_*").
+ */
+final class WildcardExtensionMatcher implements ExtensionMatcherInterface
+{
+    private string $regex;
+
+    public function __construct(string $wildcard)
+    {
+        $this->regex = $this->createRegex($wildcard);
+    }
+
+    public function matches(string $alias): bool
+    {
+        return preg_match($this->regex, $alias) === 1;
+    }
+
+    /**
+     * Convert a wildcard pattern to a regular expression.
+     *
+     * The wildcard character (*) is replaced with a regex pattern that matches any sequence of characters.
+     */
+    private function createRegex(string $wildcard): string
+    {
+        return '/^' . str_replace('\*', '.*', preg_quote($wildcard, '/')) . '$/';
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -7,6 +7,7 @@ services:
     AdamWojs\SymfonyConfigGenBundle\Command\ConfigDumpSchemaCommand:
         arguments:
             $serializerFactory: '@AdamWojs\SymfonyConfigGenBundle\Configuration\Serializer\SerializerFactory'
+            $extensionMatcherFactory: '@AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExtensionMatcherFactory'
         tags:
             - { name: console.command, command: 'config:dump-schema' }
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,6 +10,8 @@ services:
         tags:
             - { name: console.command, command: 'config:dump-schema' }
 
+    AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExtensionMatcherFactory: ~
+
     AdamWojs\SymfonyConfigGenBundle\Configuration\Serializer\SerializerFactory:
         arguments:
             $normalizers: !tagged_iterator config_schema_generator.normalizer

--- a/tests/ExtensionMatcher/CompositeExtensionMatcherTest.php
+++ b/tests/ExtensionMatcher/CompositeExtensionMatcherTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\Tests\ExtensionMatcher;
+
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\CompositeExtensionMatcher;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExplicitExtensionMatcher;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\WildcardExtensionMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class CompositeExtensionMatcherTest extends TestCase
+{
+    public function testMatchesReturnsTrueIfAnyMatcherMatches(): void
+    {
+        $matcher = new CompositeExtensionMatcher([
+            new ExplicitExtensionMatcher('foo'),
+            new WildcardExtensionMatcher('bar*'),
+        ]);
+
+        $this->assertTrue($matcher->matches('foo'));
+        $this->assertTrue($matcher->matches('bar123'));
+    }
+
+    public function testMatchesReturnsFalseIfNoMatcherMatches(): void
+    {
+        $matcher = new CompositeExtensionMatcher([
+            new ExplicitExtensionMatcher('foo'),
+            new WildcardExtensionMatcher('bar*'),
+        ]);
+
+        $this->assertFalse($matcher->matches('baz'));
+        $this->assertFalse($matcher->matches('qux'));
+    }
+
+    public function testMatchesWithEmptyMatchersArray(): void
+    {
+        $matcher = new CompositeExtensionMatcher([]);
+
+        $this->assertFalse($matcher->matches('any_alias'));
+    }
+}

--- a/tests/ExtensionMatcher/CompositeExtensionMatcherTest.php
+++ b/tests/ExtensionMatcher/CompositeExtensionMatcherTest.php
@@ -37,6 +37,6 @@ final class CompositeExtensionMatcherTest extends TestCase
     {
         $matcher = new CompositeExtensionMatcher([]);
 
-        $this->assertFalse($matcher->matches('any_alias'));
+        $this->assertTrue($matcher->matches('any_alias'));
     }
 }

--- a/tests/ExtensionMatcher/ExplicitExtensionMatcherTest.php
+++ b/tests/ExtensionMatcher/ExplicitExtensionMatcherTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\Tests\ExtensionMatcher;
+
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExplicitExtensionMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class ExplicitExtensionMatcherTest extends TestCase
+{
+    public function testMatchesReturnsTrueForMatchingAlias(): void
+    {
+        $matcher = new ExplicitExtensionMatcher('example_extension');
+
+        $this->assertTrue($matcher->matches('example_extension'));
+    }
+
+    public function testMatchesReturnsFalseForNonMatchingAlias(): void
+    {
+        $matcher = new ExplicitExtensionMatcher('example_extension');
+
+        $this->assertFalse($matcher->matches('other_alias'));
+    }
+}

--- a/tests/ExtensionMatcher/ExtensionMatcherFactoryTest.php
+++ b/tests/ExtensionMatcher/ExtensionMatcherFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\Tests\ExtensionMatcher;
+
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExtensionMatcherFactory;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExplicitExtensionMatcher;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\WildcardExtensionMatcher;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\CompositeExtensionMatcher;
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\ExtensionMatcherInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ExtensionMatcherFactoryTest extends TestCase
+{
+    public function testCreateMatcherReturnsExplicitExtensionMatcher(): void
+    {
+        $matcher = (new ExtensionMatcherFactory())->createMatcher('foo');
+
+        $this->assertInstanceOf(ExplicitExtensionMatcher::class, $matcher);
+    }
+
+    public function testCreateMatcherReturnsWildcardExtensionMatcher(): void
+    {
+        $matcher = (new ExtensionMatcherFactory())->createMatcher('bar*');
+
+        $this->assertInstanceOf(WildcardExtensionMatcher::class, $matcher);
+    }
+
+    public function testCreateCompositeMatcherReturnsCompositeExtensionMatcher(): void
+    {
+        $matcher = (new ExtensionMatcherFactory())->createCompositeMatcher(['foo', 'bar*']);
+
+        $this->assertInstanceOf(CompositeExtensionMatcher::class, $matcher);
+
+    }
+}

--- a/tests/ExtensionMatcher/WildcardExtensionMatcherTest.php
+++ b/tests/ExtensionMatcher/WildcardExtensionMatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdamWojs\SymfonyConfigGenBundle\Tests\ExtensionMatcher;
+
+use AdamWojs\SymfonyConfigGenBundle\ExtensionMatcher\WildcardExtensionMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class WildcardExtensionMatcherTest extends TestCase
+{
+    public function testMatchesWithWildcardAtEnd(): void
+    {
+        $matcher = new WildcardExtensionMatcher('acme_*');
+
+        $this->assertTrue($matcher->matches('acme_demo'));
+        $this->assertTrue($matcher->matches('acme_'));
+        $this->assertFalse($matcher->matches('acme'));
+        $this->assertFalse($matcher->matches('foo_acme_demo'));
+    }
+
+    public function testMatchesWithWildcardAtStart(): void
+    {
+        $matcher = new WildcardExtensionMatcher('*_demo');
+
+        $this->assertTrue($matcher->matches('acme_demo'));
+        $this->assertTrue($matcher->matches('_demo'));
+        $this->assertFalse($matcher->matches('acmedemo'));
+        $this->assertFalse($matcher->matches('demo_acme'));
+    }
+
+    public function testMatchesWithWildcardInMiddle(): void
+    {
+        $matcher = new WildcardExtensionMatcher('acme*_demo');
+
+        $this->assertTrue($matcher->matches('acme_demo'));
+        $this->assertTrue($matcher->matches('acme123_demo'));
+        $this->assertFalse($matcher->matches('acme'));
+        $this->assertFalse($matcher->matches('demo_acme'));
+    }
+
+    public function testMatchesWithNoWildcard(): void
+    {
+        $matcher = new WildcardExtensionMatcher('acme_demo');
+
+        $this->assertTrue($matcher->matches('acme_demo'));
+        $this->assertFalse($matcher->matches('acme_demo2'));
+        $this->assertFalse($matcher->matches('demo_acme'));
+    }
+}


### PR DESCRIPTION
### Description 

Now it's possible to run dump json schema for extensions matching wildcards e.g.

```
php bin/console config:dump-schema "ibexa_*"
```

## Checklist

- [ ] Code follows the code style of this project (use `$ composer fix-cs`).
- [ ] Change requires a change to the documentation.
- [ ] Code is ready for a review.
